### PR TITLE
Add new features about validations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kontact (0.1.0)
+    kontact (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/kontact.rb
+++ b/lib/kontact.rb
@@ -13,4 +13,17 @@ module Kontact
       raise ArgumentError, "Unsupported country: #{country}"
     end
   end
+
+  def self.valid?(number, country)
+    raise ArgumentError, "Number can not empty or blank" unless number
+
+    case country.to_sym
+    when :brazil
+      Brazil.valid?(number)
+    when :usa
+      USA.valid?(number)
+    else
+      raise ArgumentError, "Unsupported country: #{country}"
+    end
+  end
 end

--- a/lib/kontact/version.rb
+++ b/lib/kontact/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kontact
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/spec/kontact_spec.rb
+++ b/spec/kontact_spec.rb
@@ -4,4 +4,43 @@ RSpec.describe Kontact do
   it "has a version number" do
     expect(Kontact::VERSION).not_to be nil
   end
+  describe "valid?" do
+    context "when country is :brazil" do
+      it "returns true for valid brazilian number" do
+        number = Kontact::Brazil.generate
+        expect(described_class.valid?(number, :brazil)).to be true
+      end
+
+      it "returns false for invalid brazilian number" do
+        expect(described_class.valid?("+55 99 1234-5678", :brazil)).to be false
+      end
+    end
+
+    context "when country is :usa" do
+      it "returns true for valid US number" do
+        number = Kontact::USA.generate
+        expect(described_class.valid?(number, :usa)).to be true
+      end
+
+      it "returns false for invalid US number" do
+        expect(described_class.valid?("+1 000 123-4567", :usa)).to be false
+      end
+    end
+
+    context "when number is nil" do
+      it "raises ArgumentError" do
+        expect do
+          described_class.valid?(nil, :brazil)
+        end.to raise_error(ArgumentError, /Number can not empty or blank/)
+      end
+    end
+
+    context "when country is unsupported" do
+      it "raises ArgumentError" do
+        expect do
+          described_class.valid?("+55 11 91234-5678", :mexico)
+        end.to raise_error(ArgumentError, /Unsupported country/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
now, the Gem can validate a number on this way:

```ruby
Kontact.valid?(contact_number, :country)
```